### PR TITLE
Run apt update before any apt install commands

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -29,6 +29,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: latest
+      
+      - name: Prepare apt
+        run: sudo apt update
 
       - name: Install Packages
         working-directory: raw


### PR DESCRIPTION
Otherwise there's a risk of finding cached package versions that are actually no longer available to install.